### PR TITLE
Node.js test harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ typings/
 # dotenv environment variables file
 .env
 
+build/
+test.tap

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+dist: trusty
+language: node_js
+node_js:
+  - "node"
+  - "lts/*"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "program": "${workspaceFolder}\\build\\index.js",
+            "outFiles": [
+                "${workspaceFolder}/**/*.js"
+            ],
+            "args": [
+                "<path-to-test-directory>"
+            ]
+        }
+    ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,345 @@
+{
+  "name": "node-test-runner",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/node": {
+      "version": "9.6.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.5.tgz",
+      "integrity": "sha512-NOLEgsT6UiDTjnWG5Hd2Mg25LRyz/oe8ql3wbjzgSFeRzRROhPmtlsvIrei4B46UjERF0td9SZ1ZXPLOdcrBHg==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        }
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.0.tgz",
+      "integrity": "sha512-Wr/w0f4o9LuE7K53cD0qmbAMM+2XNLzR29vFn5hqko4sxGlUsyy363NvmyGIyk5tpe9cjTr9SJYbysEyPkRnFw==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.4.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.10",
+        "esprima": "4.0.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+      "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "tslib": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+      "dev": true
+    },
+    "tslint": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.9.1.tgz",
+      "integrity": "sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.4.0",
+        "commander": "2.15.1",
+        "diff": "3.5.0",
+        "glob": "7.1.2",
+        "js-yaml": "3.11.0",
+        "minimatch": "3.0.4",
+        "resolve": "1.7.1",
+        "semver": "5.5.0",
+        "tslib": "1.9.0",
+        "tsutils": "2.26.1"
+      }
+    },
+    "tsutils": {
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.26.1.tgz",
+      "integrity": "sha512-bnm9bcjOqOr1UljleL94wVCDlpa6KjfGaTkefeLch4GRafgDkROxPizbB/FxTEdI++5JqhxczRy/Qub0syNqZA==",
+      "dev": true,
+      "requires": {
+        "tslib": "1.9.0"
+      }
+    },
+    "typescript": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.1.tgz",
+      "integrity": "sha512-Ao/f6d/4EPLq0YwzsQz8iXflezpTkQzqAyenTiw4kCUGr1uPiFLC3+fZ+gMZz6eeI/qdRUqvC+HxIJzUAzEFdg==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "node-test-runner",
+  "version": "1.0.0",
+  "description": "Run core node tests using node",
+  "main": "build/index.js",
+  "scripts": {
+    "build": "tsc",
+    "lint": "tslint --project .",
+    "lint-fix": "tslint --fix --project .",
+    "prepare": "npm run build",
+    "test": "npm run lint && npm run build"
+  },
+  "author": "Kyle Farnung",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "^9.6.5",
+    "tslint": "^5.9.1",
+    "typescript": "^2.8.1"
+  },
+  "files": [
+    "build/"
+  ]
+}

--- a/src/FlagsParser.ts
+++ b/src/FlagsParser.ts
@@ -1,0 +1,28 @@
+import * as fs from "fs";
+
+class FlagsParser {
+    public static parse(filePath: string) {
+        if (!fs.existsSync(filePath)) {
+            throw new Error("Invalid file path");
+        }
+
+        const stats = fs.statSync(filePath);
+        if (!stats.isFile()) {
+            throw new Error("Invalid file path");
+        }
+
+        const flags: string[] = [];
+        const content = fs.readFileSync(filePath, "utf8");
+        const regEx = /\/\/\s+Flags:(.*)/g;
+
+        let match = null;
+        // tslint:disable-next-line:no-conditional-assignment
+        while ((match = regEx.exec(content)) !== null) {
+            flags.push(...match[1].trim().split(" "));
+        }
+
+        return flags;
+    }
+}
+
+export default FlagsParser;

--- a/src/Index.ts
+++ b/src/Index.ts
@@ -1,0 +1,21 @@
+import TapWriter from "./TapWriter";
+import TestFinder from "./TestFinder";
+
+if (process.argv.length < 3) {
+    console.error(`usage: ${process.argv[0]} ${process.argv[1]} <test-root-dir> [test-suite] [test-suite]`);
+    process.exit(1);
+}
+
+async function runTest(testDirectory: string, testSuites: string[]) {
+    const finder = new TestFinder(testDirectory, testSuites);
+    const writer = new TapWriter("test.tap", true);
+
+    for (const suite of finder.getSuites()) {
+        for (const testCase of suite.getTests()) {
+            const result = await testCase.run();
+            writer.writeResult(result);
+        }
+    }
+}
+
+runTest(process.argv[2], process.argv.slice(3));

--- a/src/StatusFile.ts
+++ b/src/StatusFile.ts
@@ -1,0 +1,143 @@
+import * as fs from "fs";
+import * as path from "path";
+
+class StatusFile {
+    private static parseSection(condition: string) {
+        if (condition === "true") {
+            return true;
+        }
+
+        let match = null;
+        let result: boolean = false;
+        let logicalOperator: string = "";
+
+        const conditionalPattern = /(\$[a-zA-Z0-9]+)(!=|==)([a-zA-Z0-9]+)(?:\s*(\|\||&&)\s*)?/g;
+
+        // tslint:disable-next-line:no-conditional-assignment
+        while ((match = conditionalPattern.exec(condition)) !== null) {
+            const temp = this.evaluateSection(match[1], match[2], match[3]);
+
+            switch (logicalOperator) {
+                case "&&":
+                    result = result && temp;
+                    break;
+
+                case "||":
+                    result = result || temp;
+                    break;
+
+                default:
+                    result = temp;
+                    break;
+            }
+
+            logicalOperator = match[4];
+        }
+
+        return result;
+    }
+
+    private static evaluateSection(field: string, comparison: string, value: string) {
+        let fieldValue = null;
+
+        switch (field) {
+            case "$arch":
+                fieldValue = process.arch;
+                break;
+
+            case "$jsEngine":
+                fieldValue = (process as any).jsEngine;
+                break;
+
+            case "$system":
+                fieldValue = process.platform;
+                break;
+
+            default:
+                throw new Error("Invalid field");
+        }
+
+        switch (comparison) {
+            case "==":
+                return fieldValue === value;
+
+            case "!=":
+                return fieldValue !== value;
+
+            default:
+                throw new Error("Invalid comparison");
+        }
+    }
+
+    private readonly filePath: string;
+    private prefix: string = "";
+    private readonly statusMap: Map<string, string[]> = new Map();
+
+    constructor(filePath: string) {
+        this.filePath = filePath;
+        this.parse();
+    }
+
+    get testPrefix() {
+        return this.prefix;
+    }
+
+    public isSkipped(testName: string) {
+        const name = path.basename(testName, path.extname(testName));
+        const status = this.statusMap.get(name);
+        if (status !== undefined) {
+            return status.indexOf("SKIP") >= 0;
+        }
+
+        return false;
+    }
+
+    public isFlaky(testName: string) {
+        const name = path.basename(testName, path.extname(testName));
+        const status = this.statusMap.get(name);
+        if (status !== undefined) {
+            return status.indexOf("FLAKY") >= 0;
+        }
+
+        return false;
+    }
+
+    private parse() {
+        if (!fs.existsSync(this.filePath)) {
+            return;
+        }
+
+        const content = fs.readFileSync(this.filePath, "utf8");
+        const lines = content.split(/\r?\n/);
+        let processRules = false;
+
+        const headerPattern = /\[([^\]]+)\]/;
+        const prefixPattern = /^\s*prefix\s+([\w\_\.\-\/]+)$/;
+        const rulePattern = /^\s*([^: ]*)\s*:(.*)/;
+
+        for (const line of lines) {
+            const headerMatch = headerPattern.exec(line);
+            if (headerMatch !== null) {
+                processRules = StatusFile.parseSection(headerMatch[1]);
+                continue;
+            }
+
+            const ruleMatch = rulePattern.exec(line);
+            if (ruleMatch !== null) {
+                if (processRules) {
+                    this.statusMap.set(ruleMatch[1], ruleMatch[2].trim().split(/, */));
+                }
+
+                continue;
+            }
+
+            const prefixMatch = prefixPattern.exec(line);
+            if (prefixMatch !== null) {
+                this.prefix = prefixMatch[1];
+                continue;
+            }
+        }
+    }
+}
+
+export default StatusFile;

--- a/src/TapWriter.ts
+++ b/src/TapWriter.ts
@@ -1,0 +1,53 @@
+import * as fs from "fs";
+import * as os from "os";
+import { ITestResult } from "./TestCase";
+
+class TapWriter {
+    private readonly writeStream: fs.WriteStream;
+    private readonly consoleEcho: boolean;
+    private testCount: number = 0;
+
+    constructor(filePath: string, consoleEcho: boolean = false) {
+        this.writeStream = fs.createWriteStream(filePath, "utf8");
+        this.writeStream.write(`TAP version 13${os.EOL}`);
+
+        this.consoleEcho = consoleEcho;
+    }
+
+    public writeResult(result: ITestResult) {
+        const outputLines: string[] = [];
+
+        let topLine = `${result.success ? "ok" : "not ok"} ${this.testCount++} ${result.name}`;
+        if (!result.success && result.flaky) {
+            topLine += " # TODO : Fix flaky test";
+        }
+        outputLines.push(topLine);
+
+        outputLines.push("  ---");
+        outputLines.push(`  duration_ms: ${Math.round(result.duration) / 1000}`);
+
+        if (!result.success) {
+            outputLines.push("  severity: fail");
+            outputLines.push(`  exitcode: ${result.exitCode}`);
+            outputLines.push("  stack: |-");
+
+            const lines = result.output.split(/\r?\n/);
+            for (const line of lines) {
+                outputLines.push(`    ${line}`);
+            }
+        }
+
+        outputLines.push("  ...");
+
+        const outputStr = outputLines.join(os.EOL);
+
+        this.writeStream.write(outputStr);
+        this.writeStream.write(os.EOL);
+
+        if (this.consoleEcho) {
+            console.log(outputStr);
+        }
+    }
+}
+
+export default TapWriter;

--- a/src/TestCase.ts
+++ b/src/TestCase.ts
@@ -1,0 +1,84 @@
+import ChildProcess from "child_process";
+import { performance } from "perf_hooks";
+import FlagsParser from "./FlagsParser";
+
+export interface ITestResult {
+    duration: number;
+    exitCode: number;
+    flaky: boolean;
+    name: string;
+    output: string;
+    success: boolean;
+}
+
+class TestCase {
+    private readonly name: string;
+    private readonly filePath: string;
+    private readonly flaky: boolean;
+    private readonly timeout: number;
+    private duration: number = 0;
+    private exitCode: number = 1;
+    private output: string = "";
+    private success: boolean = false;
+
+    constructor(name: string, filePath: string, flaky: boolean = false, timeout: number = 2 * 60 * 1000) {
+        this.name = name;
+        this.filePath = filePath;
+        this.flaky = flaky;
+        this.timeout = timeout;
+    }
+
+    public async run() {
+        const promise = new Promise((resolve, reject) => {
+            this.duration = 0;
+            this.exitCode = 1;
+            this.output = "";
+            this.success = false;
+
+            const output: string[] = [];
+            const start = performance.now();
+
+            const flags = FlagsParser.parse(this.filePath);
+            const testProcess = ChildProcess.execFile(
+                process.execPath,
+                [...flags, this.filePath],
+                { timeout: this.timeout });
+            testProcess.stdout.setEncoding("utf8");
+            testProcess.stderr.setEncoding("utf8");
+
+            testProcess.stdout.on("data", (chunk: string) => {
+                output.push(chunk);
+            });
+
+            testProcess.stderr.on("data", (chunk: string) => {
+                output.push(chunk);
+            });
+
+            testProcess.on("exit", (code: number) => {
+                this.duration = performance.now() - start;
+                this.exitCode = code;
+                this.success = (code === 0);
+                this.output = output.join("");
+
+                resolve();
+            });
+        });
+
+        await promise;
+
+        return this.getResult();
+    }
+
+    public getResult(): ITestResult {
+        return {
+            duration: this.duration,
+            exitCode: this.exitCode,
+            flaky: this.flaky,
+            name: this.name,
+            output: this.output,
+            success: this.success,
+        };
+    }
+}
+
+export default TestCase;

--- a/src/TestFinder.ts
+++ b/src/TestFinder.ts
@@ -1,0 +1,29 @@
+import * as fs from "fs";
+import * as path from "path";
+import TestSuite from "./TestSuite";
+
+class TestFinder {
+    private readonly testRoot: string;
+    private suiteNames: string[];
+
+    constructor(testRoot: string, suiteNames: string[] = []) {
+        this.testRoot = path.resolve(testRoot);
+        this.suiteNames = suiteNames;
+    }
+
+    public * getSuites() {
+        if (this.suiteNames.length === 0) {
+            this.suiteNames = fs.readdirSync(this.testRoot);
+        }
+
+        for (const item of this.suiteNames) {
+            const fullPath = path.join(this.testRoot, item);
+            const stats = fs.statSync(fullPath);
+            if (stats.isDirectory() && fs.existsSync(path.join(fullPath, "testcfg.py"))) {
+                yield new TestSuite(fullPath);
+            }
+        }
+    }
+}
+
+export default TestFinder;

--- a/src/TestSuite.ts
+++ b/src/TestSuite.ts
@@ -1,0 +1,43 @@
+import * as fs from "fs";
+import * as path from "path";
+import StatusFile from "./StatusFile";
+import TestCase from "./TestCase";
+
+class TestSuites {
+    private readonly suiteName: string;
+    private readonly suitePath: string;
+    private readonly statusFile: StatusFile;
+
+    constructor(suitePath: string) {
+        this.suiteName = path.basename(suitePath);
+        this.suitePath = path.resolve(suitePath);
+        this.statusFile = new StatusFile(path.join(this.suitePath, this.suiteName + ".status"));
+    }
+
+    get name() {
+        return this.suiteName;
+    }
+
+    public * getTests() {
+        const testPattern = /^(test-.+)\.m?js$/;
+        for (const item of fs.readdirSync(this.suitePath)) {
+            const testMatch = testPattern.exec(item);
+            if (testMatch !== null) {
+                const name = testMatch[1];
+
+                if (!this.statusFile.isSkipped(name)) {
+                    yield new TestCase(
+                        `${this.suiteName}/${name}`,
+                        path.join(this.suitePath, item),
+                        this.statusFile.isFlaky(name));
+                }
+            }
+        }
+    }
+
+    public isFlaky(name: string) {
+        return this.statusFile.isFlaky(name);
+    }
+}
+
+export default TestSuites;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "module": "commonjs",
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "outDir": "./build/",
+    "rootDir": "./src/",
+    "sourceMap": true,
+    "strict": true,
+    "strictFunctionTypes": true,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
+    "target": "es2015"
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,11 @@
+{
+    "defaultSeverity": "error",
+    "extends": [
+        "tslint:recommended"
+    ],
+    "jsRules": {},
+    "rules": {
+        "no-console": false
+    },
+    "rulesDirectory": []
+}


### PR DESCRIPTION
Given a root folder and a list of suites:
* Find the suites on disk
* For each suite
  * Parse the status file in that folder
  * Evaluate which tests should be run (not marked "SKIP")
  * Return the list of tests (with the "FLAKY" attribute accounted for)
* Outputs a TAP file

It's currently relatively basic, but lays the groundwork for future
improvements.